### PR TITLE
Fix incorrect path for injected git version tags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GIT_VERSION?=$(patsubst v%,%,${GIT_TAG})-master+${GIT_COMMIT}
 else
 GIT_VERSION?=$(patsubst v%,%,${GIT_TAG})
 endif
-LDFLAGS="-X github.com/apache/cloudstack-kubernetes-provider/vendor/k8s.io/kubernetes/pkg/version.gitVersion=${GIT_VERSION} -X github.com/apache/cloudstack-kubernetes-provider/vendor/k8s.io/kubernetes/pkg/version.gitCommit=${GIT_COMMIT} -X github.com/apache/cloudstack-kubernetes-provider/vendor/k8s.io/kubernetes/pkg/version.buildDate=${BUILD_DATE}"
+LDFLAGS="-X k8s.io/kubernetes/pkg/version.gitVersion=${GIT_VERSION} -X k8s.io/kubernetes/pkg/version.gitCommit=${GIT_COMMIT} -X k8s.io/kubernetes/pkg/version.buildDate=${BUILD_DATE}"
 export CGO_ENABLED=0
 export GO111MODULE=on
 


### PR DESCRIPTION
The k8s packages contain a set of variables that are intended to be filled with Git version information at build time.
These are later used to print version information when running cloudstack-ccm with the `--version` parameter.

Before Go modules, the vendor subtree had to be included in the symbol specification, but with full Go module support, the actual package name can be used.

This PR fixes the package names, when building with the makefile.