### PR TITLE
Don't copy the whole build context from build to runtime container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,5 +6,5 @@ RUN  make clean && CGO_ENABLED=0 GOOS=linux make
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates
 WORKDIR /root/
-COPY --from=builder /go/src/github.com/apache/cloudstack-kubernetes-provider .
+COPY --from=builder /go/src/github.com/apache/cloudstack-kubernetes-provider/cloudstack-ccm ./cloudstack-ccm
 CMD ["./cloudstack-ccm", "--cloud-provider", "external-cloudstack"]


### PR DESCRIPTION
At the moment, the whole build context including sources is copied from the build container to the runtime container.
This is a waste of resources.

Only the cloudstack-ccm binary should be copied.