### PR TITLE
Implement Travis checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: go
+
+go:
+- 1.13
+- master
+
+script: make test

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,11 @@ clean:
 cloudstack-ccm: ${CMD_SRC}
 	go build -mod vendor -ldflags ${LDFLAGS} -o $@ $^
 
+test:
+	go test -v
+	go vet
+	@(echo "gofmt -l"; FMTFILES="$$(gofmt -l .)"; if test -n "$${FMTFILES}"; then echo "Go files that need to be reformatted (use 'go fmt'):\n$${FMTFILES}"; exit 1; fi)
+
 docker:
 	docker build . -t apache/cloudstack-kubernetes-provider:${GIT_COMMIT_SHORT}
 	docker tag apache/cloudstack-kubernetes-provider:${GIT_COMMIT_SHORT} apache/cloudstack-kubernetes-provider:latest

--- a/cloudstack_loadbalancer.go
+++ b/cloudstack_loadbalancer.go
@@ -168,7 +168,7 @@ func (cs *CSCloud) EnsureLoadBalancer(ctx context.Context, clusterName string, s
 
 		if lbRule != nil {
 			klog.V(4).Infof("Creating firewall rules for load balancer rule: %v (%v:%v:%v)", lbRuleName, protocol, lbRule.Publicip, port.Port)
-			if _ , err := lb.updateFirewallRule(lbRule.Publicipid, int(port.Port), protocol, service.Spec.LoadBalancerSourceRanges); err != nil {
+			if _, err := lb.updateFirewallRule(lbRule.Publicipid, int(port.Port), protocol, service.Spec.LoadBalancerSourceRanges); err != nil {
 				return nil, err
 			}
 		}
@@ -600,29 +600,29 @@ func symmetricDifference(hostIDs []string, lbInstances []*cloudstack.VirtualMach
 //
 // Thanks to: https://stackoverflow.com/a/36000696
 func compareStringSlice(x, y []string) bool {
-    if len(x) != len(y) {
-        return false
-    }
-    // create a map of string -> int
-    diff := make(map[string]int, len(x))
-    for _, _x := range x {
-        // 0 value for int is 0, so just increment a counter for the string
-        diff[_x]++
-    }
-    for _, _y := range y {
-        // If the string _y is not in diff bail out early
-        if _, ok := diff[_y]; !ok {
-            return false
-        }
-        diff[_y] -= 1
-        if diff[_y] == 0 {
-            delete(diff, _y)
-        }
-    }
-    if len(diff) == 0 {
-        return true
-    }
-    return false
+	if len(x) != len(y) {
+		return false
+	}
+	// create a map of string -> int
+	diff := make(map[string]int, len(x))
+	for _, _x := range x {
+		// 0 value for int is 0, so just increment a counter for the string
+		diff[_x]++
+	}
+	for _, _y := range y {
+		// If the string _y is not in diff bail out early
+		if _, ok := diff[_y]; !ok {
+			return false
+		}
+		diff[_y] -= 1
+		if diff[_y] == 0 {
+			delete(diff, _y)
+		}
+	}
+	if len(diff) == 0 {
+		return true
+	}
+	return false
 }
 
 func ruleToString(rule *cloudstack.FirewallRule) string {

--- a/cmd/cloudstack-ccm/main.go
+++ b/cmd/cloudstack-ccm/main.go
@@ -30,7 +30,7 @@ import (
 	"k8s.io/component-base/logs"
 	"k8s.io/kubernetes/cmd/cloud-controller-manager/app"
 	_ "k8s.io/kubernetes/pkg/client/metrics/prometheus" // for client metric registration
-	_ "k8s.io/kubernetes/pkg/version/prometheus" // for version metric registration
+	_ "k8s.io/kubernetes/pkg/version/prometheus"        // for version metric registration
 
 	"github.com/spf13/pflag"
 

--- a/protocol.go
+++ b/protocol.go
@@ -33,14 +33,14 @@ func (p LoadBalancerProtocol) String() string {
 // Returns "" if the value is unknown.
 func (p LoadBalancerProtocol) CSProtocol() string {
 	switch p {
-		case LoadBalancerProtocolTCP:
-			return "tcp"
-		case LoadBalancerProtocolUDP:
-			return "udp"
-		case LoadBalancerProtocolTCPProxy:
-			return "tcp-proxy"
-		default:
-			return ""
+	case LoadBalancerProtocolTCP:
+		return "tcp"
+	case LoadBalancerProtocolUDP:
+		return "udp"
+	case LoadBalancerProtocolTCPProxy:
+		return "tcp-proxy"
+	default:
+		return ""
 	}
 }
 
@@ -48,14 +48,14 @@ func (p LoadBalancerProtocol) CSProtocol() string {
 // Returns "" if the value is unknown.
 func (p LoadBalancerProtocol) IPProtocol() string {
 	switch p {
-		case LoadBalancerProtocolTCP:
-			fallthrough
-		case LoadBalancerProtocolTCPProxy:
-			return "tcp"
-		case LoadBalancerProtocolUDP:
-			return "udp"
-		default:
-			return ""
+	case LoadBalancerProtocolTCP:
+		fallthrough
+	case LoadBalancerProtocolTCPProxy:
+		return "tcp"
+	case LoadBalancerProtocolUDP:
+		return "udp"
+	default:
+		return ""
 	}
 }
 
@@ -93,13 +93,13 @@ func ProtocolFromServicePort(port v1.ServicePort, annotations map[string]string)
 // CloudStack load balancer protocol name.
 func ProtocolFromLoadBalancer(protocol string) LoadBalancerProtocol {
 	switch protocol {
-		case "tcp":
-			return LoadBalancerProtocolTCP
-		case "udp":
-			return LoadBalancerProtocolUDP
-		case "tcp-proxy":
-			return LoadBalancerProtocolTCPProxy
-		default:
-			return LoadBalancerProtocolInvalid
+	case "tcp":
+		return LoadBalancerProtocolTCP
+	case "udp":
+		return LoadBalancerProtocolUDP
+	case "tcp-proxy":
+		return LoadBalancerProtocolTCPProxy
+	default:
+		return LoadBalancerProtocolInvalid
 	}
 }


### PR DESCRIPTION
This PR adds a Travis-CI script, test cases, and applies `go fmt` to satisfy the formatting check.

It should be merged after Travis is enabled on the Github repository, so we can verify that it's functioning correctly.

See also: https://github.com/apache/cloudstack-kubernetes-provider/pull/8#issuecomment-698182811 .