### PR TITLE
use non-root container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,8 @@
 FROM golang:1.13 as builder
 COPY . /go/src/github.com/apache/cloudstack-kubernetes-provider
 WORKDIR /go/src/github.com/apache/cloudstack-kubernetes-provider
-RUN apt-get update && apt-get install -y locales ca-certificates
 RUN make clean && CGO_ENABLED=0 GOOS=linux make
 
 FROM gcr.io/distroless/static:nonroot
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/src/github.com/apache/cloudstack-kubernetes-provider/cloudstack-ccm /app/cloudstack-ccm
 ENTRYPOINT [ "/app/cloudstack-ccm", "--cloud-provider", "external-cloudstack" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,12 +18,10 @@
 FROM golang:1.13 as builder
 COPY . /go/src/github.com/apache/cloudstack-kubernetes-provider
 WORKDIR /go/src/github.com/apache/cloudstack-kubernetes-provider
-RUN  make clean && CGO_ENABLED=0 GOOS=linux make
+RUN apt-get update && apt-get install -y locales ca-certificates
+RUN make clean && CGO_ENABLED=0 GOOS=linux make
 
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates
-RUN addgroup -g 1000 -S app && \
-    adduser -u 1000 -S app -G app
-USER 1000
+FROM gcr.io/distroless/static:nonroot
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/src/github.com/apache/cloudstack-kubernetes-provider/cloudstack-ccm /app/cloudstack-ccm
 ENTRYPOINT [ "/app/cloudstack-ccm", "--cloud-provider", "external-cloudstack" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ RUN  make clean && CGO_ENABLED=0 GOOS=linux make
 
 FROM alpine:latest
 RUN apk --no-cache add ca-certificates
-WORKDIR /root/
-COPY --from=builder /go/src/github.com/apache/cloudstack-kubernetes-provider/cloudstack-ccm ./cloudstack-ccm
-CMD ["./cloudstack-ccm", "--cloud-provider", "external-cloudstack"]
+RUN addgroup -g 1000 -S app && \
+    adduser -u 1000 -S app -G app
+USER 1000
+COPY --from=builder /go/src/github.com/apache/cloudstack-kubernetes-provider/cloudstack-ccm /app/cloudstack-ccm
+ENTRYPOINT [ "/app/cloudstack-ccm", "--cloud-provider", "external-cloudstack" ]

--- a/deployment.yaml
+++ b/deployment.yaml
@@ -130,8 +130,7 @@ spec:
       - name: cloud-controller-manager
         image: apache/cloudstack-kubernetes-provider:latest
         imagePullPolicy: IfNotPresent
-        command:
-        - /root/cloudstack-ccm
+        args:
         - --leader-elect=true
         - --cloud-provider=external-cloudstack
         - --cloud-config=/config/cloud-config


### PR DESCRIPTION
I have detected that our container
1. does run as root user
2. can't run as non-root user

Therefore, I updated the deployment to run as user 1000 by default and moved the binary out of the `/root/` directory.

Also, I changed the `CMD` to `ENTRYPOINT`, so you can use `args` in the Kubernetes deployment. Then you don't need to know the command to start the daemon and can just add multiple arguments

Ref:
- https://amazicworld.com/get-the-evil-out-dont-run-containers-as-root/
- https://engineering.bitnami.com/articles/why-non-root-containers-are-important-for-security.html