### PR TITLE
Improve readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # CloudStack Kubernetes Provider
 
-[![](https://img.shields.io/github/release/apache/cloudstack-kubernetes-provider.svg?style=flat-square "Release")](https://github.com/apache/cloudstack-kubernetes-provider/releases)
-[![](https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat-square "Apache 2.0 license")](/LICENSE-2.0)
-[![](https://img.shields.io/badge/language-Go-%235adaff.svg?style=flat-square "Go language")](https://golang.org)
-[![](https://img.shields.io/docker/build/apache/cloudstack-kubernetes-provider.svg?style=flat-square "Docker build status")](https://hub.docker.com/r/apache/cloudstack-kubernetes-provider/)
+[![](https://img.shields.io/github/release/apache/cloudstack-kubernetes-provider.svg?logo=github&style=flat-square "Release")](https://github.com/apache/cloudstack-kubernetes-provider/releases)
+[![](https://img.shields.io/badge/license-Apache%202.0-blue.svg?color=%23282661&logo=apache&style=flat-square "Apache 2.0 license")](/LICENSE-2.0)
+[![](https://img.shields.io/badge/language-Go-%235adaff.svg?logo=go&style=flat-square "Go language")](https://golang.org)
+[![](https://img.shields.io/docker/v/apache/cloudstack-kubernetes-provider?label=docker%20hub&logo=docker&style=flat-square "Docker Hub Image Version")](https://hub.docker.com/r/apache/cloudstack-kubernetes-provider/)
 
 A Cloud Controller Manager to facilitate Kubernetes deployments on Cloudstack.
 


### PR DESCRIPTION
The Docker Hub badge won't work when the images are built elsewhere.

I replaced it with a version badge and also improved the other badges a bit.

The release badge will report an error until we tag the first release version on Github.