### PR TITLE
deployment.yaml: add tolerations

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -166,3 +166,8 @@ spec:
       - name: config-volume
         secret:
           secretName: cloudstack-secret
+      tolerations:
+      # this is required so CCM can bootstrap itself
+      - key: node.cloudprovider.kubernetes.io/uninitialized
+        value: "true"
+        effect: NoSchedule


### PR DESCRIPTION
Without it, the ccm itself cannot be started when nodes are tainted.

Reference: https://kubernetes.io/docs/tasks/administer-cluster/running-cloud-controller/#running-cloud-controller-manager