### PR TITLE
Fix providerID handling + label sanitizing

### DIFF
--- a/cloudstack.go
+++ b/cloudstack.go
@@ -34,7 +34,7 @@ import (
 )
 
 // ProviderName is the name of this cloud provider.
-const ProviderName = "external-cloudstack"
+const ProviderName = "cloudstack"
 
 // CSConfig wraps the config for the CloudStack cloud provider.
 type CSConfig struct {
@@ -199,13 +199,18 @@ func (cs *CSCloud) GetZone(ctx context.Context) (cloudprovider.Zone, error) {
 func (cs *CSCloud) GetZoneByProviderID(ctx context.Context, providerID string) (cloudprovider.Zone, error) {
 	zone := cloudprovider.Zone{}
 
+	id, _, err := instanceIDFromProviderID(providerID)
+	if err != nil {
+		return zone, err
+	}
+
 	instance, count, err := cs.client.VirtualMachine.GetVirtualMachineByID(
-		providerID,
+		id,
 		cloudstack.WithProject(cs.projectID),
 	)
 	if err != nil {
 		if count == 0 {
-			return zone, fmt.Errorf("could not find node by ID: %v", providerID)
+			return zone, fmt.Errorf("could not find node by ID: %v", id)
 		}
 		return zone, fmt.Errorf("error retrieving zone: %v", err)
 	}

--- a/cloudstack_instances.go
+++ b/cloudstack_instances.go
@@ -29,7 +29,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
-	"k8s.io/klog/v2"
 )
 
 var labelInvalidCharsRegex *regexp.Regexp = regexp.MustCompile(`([^A-Za-z0-9][^-A-Za-z0-9_.]*)?[^A-Za-z0-9]`)
@@ -86,10 +85,6 @@ func (cs *CSCloud) nodeAddresses(instance *cloudstack.VirtualMachine) ([]corev1.
 
 	if instance.Publicip != "" {
 		addresses = append(addresses, corev1.NodeAddress{Type: corev1.NodeExternalIP, Address: instance.Publicip})
-	} else {
-		// Since there is no sane way to determine the external IP if the host isn't
-		// using static NAT, we will just fire a log message and omit the external IP.
-		klog.V(4).Infof("Could not determine the public IP of host %v (%v)", instance.Name, instance.Id)
 	}
 
 	return addresses, nil

--- a/cloudstack_instances.go
+++ b/cloudstack_instances.go
@@ -23,15 +23,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"regexp"
 
 	"github.com/apache/cloudstack-go/v2/cloudstack"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 	cloudprovider "k8s.io/cloud-provider"
 )
-
-var labelInvalidCharsRegex *regexp.Regexp = regexp.MustCompile(`([^A-Za-z0-9][^-A-Za-z0-9_.]*)?[^A-Za-z0-9]`)
 
 // NodeAddresses returns the addresses of the specified instance.
 func (cs *CSCloud) NodeAddresses(ctx context.Context, name types.NodeName) ([]corev1.NodeAddress, error) {
@@ -119,7 +116,7 @@ func (cs *CSCloud) InstanceType(ctx context.Context, name types.NodeName) (strin
 		return "", fmt.Errorf("error retrieving instance type: %v", err)
 	}
 
-	return labelInvalidCharsRegex.ReplaceAllString(instance.Serviceofferingname, ``), nil
+	return sanitizeLabel(instance.Serviceofferingname), nil
 }
 
 // InstanceTypeByProviderID returns the type of the specified instance.
@@ -140,7 +137,7 @@ func (cs *CSCloud) InstanceTypeByProviderID(ctx context.Context, providerID stri
 		return "", fmt.Errorf("error retrieving instance type: %v", err)
 	}
 
-	return labelInvalidCharsRegex.ReplaceAllString(instance.Serviceofferingname, ``), nil
+	return sanitizeLabel(instance.Serviceofferingname), nil
 }
 
 // AddSSHKeyToAllInstances is currently not implemented.
@@ -232,9 +229,9 @@ func (cs *CSCloud) InstanceMetadata(ctx context.Context, node *corev1.Node) (*cl
 
 	return &cloudprovider.InstanceMetadata{
 		ProviderID:    node.Spec.ProviderID,
-		InstanceType:  labelInvalidCharsRegex.ReplaceAllString(instance.Serviceofferingname, ``),
+		InstanceType:  sanitizeLabel(instance.Serviceofferingname),
 		NodeAddresses: addresses,
-		Zone:          labelInvalidCharsRegex.ReplaceAllString(instance.Zonename, ``),
+		Zone:          sanitizeLabel(instance.Zonename),
 		Region:        region,
 	}, nil
 }

--- a/cloudstack_instances.go
+++ b/cloudstack_instances.go
@@ -52,8 +52,13 @@ func (cs *CSCloud) NodeAddresses(ctx context.Context, name types.NodeName) ([]co
 
 // NodeAddressesByProviderID returns the addresses of the specified instance.
 func (cs *CSCloud) NodeAddressesByProviderID(ctx context.Context, providerID string) ([]corev1.NodeAddress, error) {
+	id, _, err := instanceIDFromProviderID(providerID)
+	if err != nil {
+		return nil, err
+	}
+
 	instance, count, err := cs.client.VirtualMachine.GetVirtualMachineByID(
-		providerID,
+		id,
 		cloudstack.WithProject(cs.projectID),
 	)
 	if err != nil {
@@ -124,8 +129,13 @@ func (cs *CSCloud) InstanceType(ctx context.Context, name types.NodeName) (strin
 
 // InstanceTypeByProviderID returns the type of the specified instance.
 func (cs *CSCloud) InstanceTypeByProviderID(ctx context.Context, providerID string) (string, error) {
+	id, _, err := instanceIDFromProviderID(providerID)
+	if err != nil {
+		return "", err
+	}
+
 	instance, count, err := cs.client.VirtualMachine.GetVirtualMachineByID(
-		providerID,
+		id,
 		cloudstack.WithProject(cs.projectID),
 	)
 	if err != nil {
@@ -150,8 +160,13 @@ func (cs *CSCloud) CurrentNodeName(ctx context.Context, hostname string) (types.
 
 // InstanceExistsByProviderID returns if the instance still exists.
 func (cs *CSCloud) InstanceExistsByProviderID(ctx context.Context, providerID string) (bool, error) {
+	id, _, err := instanceIDFromProviderID(providerID)
+	if err != nil {
+		return false, err
+	}
+
 	_, count, err := cs.client.VirtualMachine.GetVirtualMachineByID(
-		providerID,
+		id,
 		cloudstack.WithProject(cs.projectID),
 	)
 	if err != nil {
@@ -166,7 +181,22 @@ func (cs *CSCloud) InstanceExistsByProviderID(ctx context.Context, providerID st
 
 // InstanceShutdownByProviderID returns true if the instance is in safe state to detach volumes
 func (cs *CSCloud) InstanceShutdownByProviderID(ctx context.Context, providerID string) (bool, error) {
-	return false, cloudprovider.NotImplemented
+	id, _, err := instanceIDFromProviderID(providerID)
+	if err != nil {
+		return false, err
+	}
+
+	instance, count, err := cs.client.VirtualMachine.GetVirtualMachineByID(
+		id,
+		cloudstack.WithProject(cs.projectID),
+	)
+	if err != nil {
+		if count == 0 {
+			return false, cloudprovider.InstanceNotFound
+		}
+		return false, fmt.Errorf("error retrieving instance state: %v", err)
+	}
+	return instance != nil && instance.State == "Stopped", nil
 }
 
 func (cs *CSCloud) InstanceExists(ctx context.Context, node *corev1.Node) (bool, error) {
@@ -180,31 +210,36 @@ func (cs *CSCloud) InstanceExists(ctx context.Context, node *corev1.Node) (bool,
 }
 
 func (cs *CSCloud) InstanceShutdown(ctx context.Context, node *corev1.Node) (bool, error) {
-	return false, cloudprovider.NotImplemented
+	return cs.InstanceShutdownByProviderID(ctx, node.Spec.ProviderID)
 }
 
 func (cs *CSCloud) InstanceMetadata(ctx context.Context, node *corev1.Node) (*cloudprovider.InstanceMetadata, error) {
-
-	instanceType, err := cs.InstanceType(ctx, types.NodeName(node.Name))
+	id, region, err := instanceIDFromProviderID(node.Spec.ProviderID)
 	if err != nil {
 		return nil, err
 	}
 
-	addresses, err := cs.NodeAddresses(ctx, types.NodeName(node.Name))
+	instance, count, err := cs.client.VirtualMachine.GetVirtualMachineByID(
+		id,
+		cloudstack.WithProject(cs.projectID),
+	)
 	if err != nil {
-		return nil, err
+		if count == 0 {
+			return nil, cloudprovider.InstanceNotFound
+		}
+		return nil, fmt.Errorf("error retrieving instance: %v", err)
 	}
 
-	zone, err := cs.GetZone(ctx)
+	addresses, err := cs.nodeAddresses(instance)
 	if err != nil {
 		return nil, err
 	}
 
 	return &cloudprovider.InstanceMetadata{
-		ProviderID:    cs.ProviderName(),
-		InstanceType:  instanceType,
+		ProviderID:    node.Spec.ProviderID,
+		InstanceType:  labelInvalidCharsRegex.ReplaceAllString(instance.Serviceofferingname, ``),
 		NodeAddresses: addresses,
-		Zone:          cs.zone,
-		Region:        zone.Region,
+		Zone:          labelInvalidCharsRegex.ReplaceAllString(instance.Zonename, ``),
+		Region:        region,
 	}, nil
 }

--- a/util.go
+++ b/util.go
@@ -45,3 +45,29 @@ func instanceIDFromProviderID(providerID string) (instanceID string, region stri
 	}
 	return matches[2], matches[1], nil
 }
+
+// Sanitize label value so it complies with https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
+// Anything but [-A-Za-z0-9_.] will get converted to '_'
+func sanitizeLabel(value string) string {
+	fn := func(r rune) rune {
+		if r >= 'a' && r <= 'z' ||
+			r >= 'A' && r <= 'Z' ||
+			r >= '0' && r <= '9' ||
+			r == '-' || r == '_' || r == '.' {
+			return r
+		}
+		return '_'
+	}
+	value = strings.Map(fn, value)
+
+	// Must start & end with alphanumeric char
+	value = strings.Trim(value, "-_.")
+
+	// Strip anything over 63 chars
+	if len(value) > 63 {
+		value = value[:63]
+		value = strings.Trim(value, "-_.")
+	}
+
+	return value
+}

--- a/util.go
+++ b/util.go
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package cloudstack
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// If Instances.InstanceID or cloudprovider.GetInstanceProviderID is changed, the regexp should be changed too.
+var providerIDRegexp = regexp.MustCompile(`^` + ProviderName + `://([^/]*)/([^/]+)$`)
+
+// instanceIDFromProviderID splits a provider's id and return instanceID.
+// A providerID is build out of '${ProviderName}:///${instance-id}' which contains ':///'.
+// or '${ProviderName}://${region}/${instance-id}' which contains '://'.
+// See cloudprovider.GetInstanceProviderID and Instances.InstanceID.
+func instanceIDFromProviderID(providerID string) (instanceID string, region string, err error) {
+
+	// https://github.com/kubernetes/kubernetes/issues/85731
+	if providerID != "" && !strings.Contains(providerID, "://") {
+		providerID = ProviderName + "://" + providerID
+	}
+
+	matches := providerIDRegexp.FindStringSubmatch(providerID)
+	if len(matches) != 3 {
+		return "", "", fmt.Errorf("ProviderID \"%s\" didn't match expected format \"cloudstack://region/InstanceID\"", providerID)
+	}
+	return matches[2], matches[1], nil
+}

--- a/util.go
+++ b/util.go
@@ -26,7 +26,7 @@ import (
 )
 
 // If Instances.InstanceID or cloudprovider.GetInstanceProviderID is changed, the regexp should be changed too.
-var providerIDRegexp = regexp.MustCompile(`^` + ProviderName + `://([^/]*)/([^/]+)$`)
+var providerIDRegexp = regexp.MustCompile(`^` + ProviderName + `://?([^/]*)/([^/]+)$`)
 
 // instanceIDFromProviderID splits a provider's id and return instanceID.
 // A providerID is build out of '${ProviderName}:///${instance-id}' which contains ':///'.


### PR DESCRIPTION
This PR changes the way the CloudStack Cloud Controller Manager handles kubelet providerID into a more standardized way that is more common around several other CCM's like the Openstack or vSphere one. The changes were needed to make node labels work again.

The providerID is configured by either setting the kubelet command line flag `--provider-id` (deprecated) or using the `providerID` setting in [kubelet config yaml](https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/). The format of the value is `<providername>://region/instance-id` so in case of CloudStack for a platform without region f.e. : `cloudstack:///4e7689bc-99ea-43d8-8c37-5ff511c01665`. With the region being parsed from the providerID, this PR also addresses #39 

It also implements the two interface methods `InstanceShutdownByProviderID` and `InstanceShutdown`.

And it fixes the way node labels are sanitized. The old regex approach would in some cases strip off allowed characters, for example zone name `Development-Internal` would turn into `DevelopmentInternal`, although the `-` is allowed in label values. The new approach converts all chars that are not allowed in a label value to underscores:

`Development-Internal` -> `Development-Internal`
`Small Instance (4 GB / 2 CPU)` -> `Small_Instance__4_GB___2_CPU`

