### PR TITLE
Strip domain from node.Name before matching with vm names

### DIFF
--- a/cloudstack_loadbalancer.go
+++ b/cloudstack_loadbalancer.go
@@ -332,7 +332,9 @@ func (cs *CSCloud) getLoadBalancer(service *corev1.Service) (*loadBalancer, erro
 func (cs *CSCloud) verifyHosts(nodes []*corev1.Node) ([]string, string, error) {
 	hostNames := map[string]bool{}
 	for _, node := range nodes {
-		hostNames[strings.ToLower(node.Name)] = true
+		// node.Name can be an FQDN as well, and CloudStack VM names aren't
+		// To match, we need to Split the domain part off here, if present
+		hostNames[strings.Split(strings.ToLower(node.Name), ".")[0]] = true
 	}
 
 	p := cs.client.VirtualMachine.NewListVirtualMachinesParams()
@@ -360,6 +362,10 @@ func (cs *CSCloud) verifyHosts(nodes []*corev1.Node) ([]string, string, error) {
 			networkID = vm.Nic[0].Networkid
 			hostIDs = append(hostIDs, vm.Id)
 		}
+	}
+
+	if len(hostIDs) == 0 || len(networkID) == 0 {
+		return nil, "", fmt.Errorf("none of the hosts matched the list of VMs retrieved from CS API")
 	}
 
 	return hostIDs, networkID, nil


### PR DESCRIPTION
Kubernetes node.Name can contain a FQDN instead of just a hostname in some setups. This PR makes sure to strip the domain part before trying to match with VM names from the CS API, since CloudStack does not have the concept of FQDN VM names.

It also adds some sanity checking in case verifyHosts is about to return an empty hostIDs array or empty networkID (this is how i ran into this issue)