### PR TITLE
NSX: (temp fix) Skip adding firewall rules for CKS Clusters on VPC tiers

### DIFF
--- a/cloudstack_loadbalancer.go
+++ b/cloudstack_loadbalancer.go
@@ -163,8 +163,11 @@ func (cs *CSCloud) EnsureLoadBalancer(ctx context.Context, clusterName string, s
 			}
 		}
 
-		network, _, err := cs.client.Network.GetNetworkByID(lb.networkID, nil)
+		network, count, err := lb.Network.GetNetworkByID(lb.networkID, cloudstack.WithProject(lb.projectID))
 		if err != nil {
+			if count == 0 {
+				return nil, err
+			}
 			return nil, err
 		}
 


### PR DESCRIPTION
Currently CKP does not setup NetworkACLs for CKS clusters on VPC tiers, and fails to add Firewall rules - as Firewall isn't supported on VPCs. This is a partial fix, to skip setting up Firewall rules if the network doesn't support the service.