### PR TITLE
Fix for service.beta.kubernetes.io/cloudstack-load-balancer-proxy-protocol

### DIFF
--- a/nginx-ingress-controller-patch.yml
+++ b/nginx-ingress-controller-patch.yml
@@ -24,7 +24,7 @@ metadata:
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
   annotations:
-    service.beta.kubernetes.io/cloudstack-load-balancer-proxy-protocol: enabled
+    service.beta.kubernetes.io/cloudstack-load-balancer-proxy-protocol: 'true'
 spec:
   type: LoadBalancer
   selector:

--- a/traefik-ingress-controller.yml
+++ b/traefik-ingress-controller.yml
@@ -20,7 +20,7 @@ kind: Service
 metadata:
   name: traefik
   annotations:
-    service.beta.kubernetes.io/cloudstack-load-balancer-proxy-protocol: enabled
+    service.beta.kubernetes.io/cloudstack-load-balancer-proxy-protocol: 'true'
 spec:
   type: LoadBalancer
   ports:


### PR DESCRIPTION
As per source code, annotation should be having a value of 'true' or 'false' and not enabled. The existing examples are incorrect. 

service.beta.kubernetes.io/cloudstack-load-balancer-proxy-protocol: 'true'